### PR TITLE
Improve C compatibility of flat client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.29.2)
 
 # Setup vcpkg
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake)
+if (DEFINED ENV{VCPKG_ROOT})
+	set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+else()
+	set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake)
+endif()
 
 if (DEFINED CMAKE_BUILD_ARM64_LINUX)
 	# arm64-linux-gnu.toolchain.cmake
@@ -112,6 +116,7 @@ target_sources(afv_native PRIVATE
 			${CMAKE_CURRENT_SOURCE_DIR}/src/core/atcClient.cpp
 			${CMAKE_CURRENT_SOURCE_DIR}/src/core/atisClient.cpp
 			${CMAKE_CURRENT_SOURCE_DIR}/src/atcClientWrapper.cpp
+			${CMAKE_CURRENT_SOURCE_DIR}/src/atcClientFlat.cpp
 			${CMAKE_CURRENT_SOURCE_DIR}/extern/simpleSource/SimpleComp.cpp
 			${CMAKE_CURRENT_SOURCE_DIR}/extern/simpleSource/SimpleEnvelope.cpp
 			${CMAKE_CURRENT_SOURCE_DIR}/extern/simpleSource/SimpleGate.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if(EXISTS "${PROJECT_SOURCE_DIR}/test/afv-native-testclient/CMakeLists.txt" AND 
 	add_subdirectory(test/afv-native-testclient)
 endif()
 
-target_sources(afv_native PRIVATE 
+target_sources(afv_native PRIVATE
 			${CMAKE_CURRENT_SOURCE_DIR}/src/afv/APISession.cpp
 			${CMAKE_CURRENT_SOURCE_DIR}/src/afv/EffectResources.cpp
 			${CMAKE_CURRENT_SOURCE_DIR}/src/afv/RadioSimulation.cpp
@@ -152,7 +152,7 @@ if (WIN32)
 	find_library(SPEEXDSP_LIBRARY speexdsp.lib)
 endif()
 
-set(LIBRARIES 
+set(LIBRARIES
 		OpenSSL::SSL OpenSSL::Crypto
 		cpp-jwt::cpp-jwt
 		CURL::libcurl
@@ -204,7 +204,7 @@ set_target_properties(afv_native PROPERTIES DEBUG_POSTFIX "d")
 
 # generates header to provide export macros for library
 include(GenerateExportHeader)
-generate_export_header(afv_native 
+generate_export_header(afv_native
 						EXPORT_MACRO_NAME AFV_NATIVE_API
 						EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/include/afv_native_export.h)
 
@@ -223,12 +223,12 @@ install(
     NAMESPACE afv_native::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/afv_native)
 
-install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/afv_native/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/afv_native)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/afv-native/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/afv-native)
 
 # copy the generated export file to the include install location
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/afv_native_export.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/afv_native)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/afv-native)
 
 if (WIN32)
 	file(COPY ${SPEEXDSP_LIBRARY}

--- a/include/afv-native/afv/dto/interfaces/IAudio.h
+++ b/include/afv-native/afv/dto/interfaces/IAudio.h
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace afv_native { namespace afv { namespace dto {
     class IAudio {

--- a/include/afv-native/atcClientFlat.h
+++ b/include/afv-native/atcClientFlat.h
@@ -1,12 +1,15 @@
 #ifndef atcClientFlat_h
 #define atcClientFlat_h
 
-#include "afv-native/atcClient.h"
-#include "afv-native/atcClientWrapper.h"
+#include "afv-native/event.h"
+#include "afv-native/hardwareType.h"
+#include "afv_native_export.h"
+
+#include <stdbool.h>
 
 typedef struct StationTransceiverFlat {
-    char  *ID;
-    char  *Name;
+    const char  *ID;
+    const char  *Name;
     double LatDeg;
     double LonDeg;
     double HeightMslM;
@@ -14,11 +17,53 @@ typedef struct StationTransceiverFlat {
 
 } StationTransceiverFlat_t;
 
+typedef struct AFV_NATIVE_API AudioInterfaceNative {
+    const char *id;
+    const char *name;
+    bool  isDefault;
+} AudioInterfaceNative_t;
+
+typedef enum ClientEventType {
+    APIServerConnected,
+    APIServerDisconnected,
+    APIServerError, // data is a pointer to the APISessionError
+    VoiceServerConnected,
+    VoiceServerDisconnected,
+    VoiceServerChannelError, // data is a pointer to an int containing the errno
+    VoiceServerError,        // data is a pointer to the VoiceSessionError
+    PttOpen,
+    PttClosed,
+    StationAliasesUpdated,
+    StationTransceiversUpdated,
+    FrequencyRxBegin, // data is a pointer to an unsigned int containing the frequency
+    FrequencyRxEnd, // data is a pointer to an unsigned int containing the frequency
+    StationRxBegin, // data is a pointer to an unsigned int containing the frequency, data2 is pointer to char* containing callsign
+    StationRxEnd, // data is a pointer to an unsigned int containing the frequency, data2 is pointer to char* containing callsign
+    AudioError,
+    VccsReceived,
+    StationDataReceived,
+    InputDeviceError,
+    AudioDisabled,
+    AudioDeviceStoppedError, // data is a pointer to a std::string of the relevant device name
+} ClientEventType_t;
+
+typedef enum PlaybackChannel {
+    Both,
+    Left,
+    Right
+} PlaybackChannel_t;
+
+typedef enum HardwareType {
+    Schmid_ED_137B,
+    Rockwell_Collins_2100,
+    Garex_220
+} HardwareType_t;
+
 typedef struct ATCClientHandle_ *ATCClientHandle;
 
 typedef void (*CharStarCallback)(const char *);
 typedef void (*AudioApisCallback)(unsigned int id, const char *);
-typedef void (*AudioInterfaceNativeCallback)(char *id, char *name, bool isDefault);
+typedef void (*AudioInterfaceNativeCallback)(const char *id, const char *name, bool isDefault);
 
 /*
 struct AFV_NATIVE_API AudioInterfaceNative {
@@ -42,13 +87,15 @@ struct AFV_NATIVE_API AudioInterfaceNative {
 
 */
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 
-    AFV_NATIVE_API ATCClientHandle ATCClient_Create(char *clientName, char *resourcePath, char *baseURL);
+    AFV_NATIVE_API ATCClientHandle ATCClient_Create(const char *clientName, const char *resourcePath, const char *baseURL);
     AFV_NATIVE_API void ATCClient_Destroy(ATCClientHandle handle);
     AFV_NATIVE_API bool ATCClient_IsInitialized(ATCClientHandle handle);
-    AFV_NATIVE_API void ATCClient_SetCredentials(ATCClientHandle handle, char *username, char *password);
-    AFV_NATIVE_API void ATCClient_SetCallsign(ATCClientHandle handle, char *callsign);
+    AFV_NATIVE_API void ATCClient_SetCredentials(ATCClientHandle handle, const char *username, char *password);
+    AFV_NATIVE_API void ATCClient_SetCallsign(ATCClientHandle handle, const char *callsign);
     AFV_NATIVE_API void ATCClient_SetClientPosition(ATCClientHandle handle, double lat, double lon, double amslm, double aglm);
     AFV_NATIVE_API bool ATCClient_IsVoiceConnected(ATCClientHandle handle);
     AFV_NATIVE_API bool ATCClient_IsAPIConnected(ATCClientHandle handle);
@@ -57,14 +104,14 @@ extern "C" {
     AFV_NATIVE_API void ATCClient_SetAudioApi(ATCClientHandle handle, unsigned int api);
     AFV_NATIVE_API void ATCClient_GetAudioApis(ATCClientHandle handle, AudioApisCallback callback);
     AFV_NATIVE_API void ATCClient_FreeAudioApis(ATCClientHandle handle, char **apis);
-    AFV_NATIVE_API void ATCClient_SetAudioInputDevice(ATCClientHandle handle, char *inputDevice);
+    AFV_NATIVE_API void ATCClient_SetAudioInputDevice(ATCClientHandle handle, const char *inputDevice);
     AFV_NATIVE_API void ATCClient_GetAudioInputDevices(ATCClientHandle handle, unsigned int mAudioApi, AudioInterfaceNativeCallback callback);
     AFV_NATIVE_API const char *ATCClient_GetDefaultAudioInputDevice(ATCClientHandle handle, unsigned int mAudioApi);
-    AFV_NATIVE_API void ATCClient_SetAudioOutputDevice(ATCClientHandle handle, char *outputDevice);
-    AFV_NATIVE_API void ATCClient_SetAudioSpeakersOutputDevice(ATCClientHandle handle, char *outputDevice);
+    AFV_NATIVE_API void ATCClient_SetAudioOutputDevice(ATCClientHandle handle, const char *outputDevice);
+    AFV_NATIVE_API void ATCClient_SetAudioSpeakersOutputDevice(ATCClientHandle handle, const char *outputDevice);
     AFV_NATIVE_API void ATCClient_GetAudioOutputDevices(ATCClientHandle handle, unsigned int mAudioApi, AudioInterfaceNativeCallback callback);
     AFV_NATIVE_API const char *ATCClient_GetDefaultAudioOutputDevice(ATCClientHandle handle, unsigned int mAudioApi);
-    AFV_NATIVE_API void ATCClient_FreeAudioDevices(ATCClientHandle handle, afv_native::api::AudioInterfaceNative **in);
+    AFV_NATIVE_API void ATCClient_FreeAudioDevices(ATCClientHandle handle, AudioInterfaceNative_t **in);
     AFV_NATIVE_API const double ATCClient_GetInputPeak(ATCClientHandle handle);
     AFV_NATIVE_API const double ATCClient_GetInputVu(ATCClientHandle handle);
     AFV_NATIVE_API void ATCClient_SetEnableInputFilters(ATCClientHandle handle, bool enableInputFilters);
@@ -85,18 +132,18 @@ extern "C" {
     AFV_NATIVE_API bool ATCClient_GetRxState(ATCClientHandle handle, unsigned int freq);
     AFV_NATIVE_API bool ATCClient_GetXcState(ATCClientHandle handle, unsigned int freq);
     AFV_NATIVE_API bool ATCClient_GetCrossCoupleAcrossState(ATCClientHandle handle, unsigned int freq);
-    AFV_NATIVE_API void ATCClient_UseTransceiversFromStation(ATCClientHandle handle, char *station, unsigned int freq);
-    AFV_NATIVE_API void ATCClient_FetchTransceiverInfo(ATCClientHandle handle, char *station);
-    AFV_NATIVE_API void ATCClient_FetchStationVccs(ATCClientHandle handle, char *station);
-    AFV_NATIVE_API void ATCClient_GetStation(ATCClientHandle handle, char *station);
-    AFV_NATIVE_API int ATCClient_GetTransceiverCountForStation(ATCClientHandle handle, char *station);
+    AFV_NATIVE_API void ATCClient_UseTransceiversFromStation(ATCClientHandle handle, const char *station, unsigned int freq);
+    AFV_NATIVE_API void ATCClient_FetchTransceiverInfo(ATCClientHandle handle, const char *station);
+    AFV_NATIVE_API void ATCClient_FetchStationVccs(ATCClientHandle handle, const char *station);
+    AFV_NATIVE_API void ATCClient_GetStation(ATCClientHandle handle, const char *station);
+    AFV_NATIVE_API int ATCClient_GetTransceiverCountForStation(ATCClientHandle handle, const char *station);
     AFV_NATIVE_API int ATCClient_GetTransceiverCountForFrequency(ATCClientHandle handle, unsigned int freq);
     AFV_NATIVE_API void ATCClient_SetPtt(ATCClientHandle handle, bool pttState);
     AFV_NATIVE_API const char *ATCClient_LastTransmitOnFreq(ATCClientHandle handle, unsigned int freq);
     AFV_NATIVE_API void ATCClient_SetRadioGainAll(ATCClientHandle handle, float gain);
     AFV_NATIVE_API void ATCClient_SetRadioGain(ATCClientHandle handle, unsigned int freq, float gain);
-    AFV_NATIVE_API void ATCClient_SetPlaybackChannelAll(ATCClientHandle handle, afv_native::PlaybackChannel channel);
-    AFV_NATIVE_API void ATCClient_SetPlaybackChannel(ATCClientHandle handle, unsigned int freq, afv_native::PlaybackChannel channel);
+    AFV_NATIVE_API void ATCClient_SetPlaybackChannelAll(ATCClientHandle handle, PlaybackChannel_t channel);
+    AFV_NATIVE_API void ATCClient_SetPlaybackChannel(ATCClientHandle handle, unsigned int freq, PlaybackChannel_t channel);
     AFV_NATIVE_API int ATCClient_GetPlaybackChannel(ATCClientHandle handle, unsigned int freq);
     AFV_NATIVE_API bool ATCClient_AddFrequency(ATCClientHandle handle, unsigned int freq, char *stationName);
     AFV_NATIVE_API void ATCClient_RemoveFrequency(ATCClientHandle handle, unsigned int freq);
@@ -105,9 +152,11 @@ extern "C" {
     // void ATCClient_FreeRadioState(ATCClientHandle handle, afv_native::SimpleAtcRadioState **state);
     AFV_NATIVE_API void ATCClient_Reset(ATCClientHandle handle);
     AFV_NATIVE_API void ATCClient_FreeString(ATCClientHandle handle, char *in);
-    AFV_NATIVE_API void ATCClient_SetHardware(ATCClientHandle handle, afv_native::HardwareType hardware);
-    AFV_NATIVE_API void ATCClient_RaiseClientEvent(ATCClientHandle handle, void (*callback)(afv_native::ClientEventType, void *, void *));
+    AFV_NATIVE_API void ATCClient_SetHardware(ATCClientHandle handle, HardwareType_t hardware);
+    AFV_NATIVE_API void ATCClient_RaiseClientEvent(ATCClientHandle handle, void (*callback)(ClientEventType_t, void *, void *));
     AFV_NATIVE_API void ATCClient_SetTransceivers(ATCClientHandle handle, unsigned int freq, int count, StationTransceiverFlat_t transceivers[]);
+#ifdef __cplusplus
 }
+#endif
 
 #endif

--- a/include/afv-native/atcClientFlat.h
+++ b/include/afv-native/atcClientFlat.h
@@ -1,8 +1,6 @@
 #ifndef atcClientFlat_h
 #define atcClientFlat_h
 
-#include "afv-native/event.h"
-#include "afv-native/hardwareType.h"
 #include "afv_native_export.h"
 
 #include <stdbool.h>

--- a/include/afv-native/atcClientWrapper.h
+++ b/include/afv-native/atcClientWrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "afv-native/afv/dto/StationTransceiver.h"
+#include "afv-native/atcClientFlat.h"
 #include "afv_native_export.h"
 #include "event.h"
 #include "hardwareType.h"
@@ -48,16 +49,16 @@ namespace afv_native::api {
     class atcClient {
       public:
         AFV_NATIVE_API atcClient(std::string clientName, std::string resourcePath = "", std::string baseURL = "https://voice1.vatsim.net");
-        AFV_NATIVE_API atcClient(char *clientName, char *resourcePath, char *baseURL);
+        AFV_NATIVE_API atcClient(const char *clientName, const char *resourcePath, const char *baseURL);
         AFV_NATIVE_API ~atcClient();
 
         AFV_NATIVE_API bool IsInitialized();
 
         AFV_NATIVE_API void SetCredentials(std::string username, std::string password);
-        AFV_NATIVE_API void SetCredentials(char *username, char *password);
+        AFV_NATIVE_API void SetCredentials(const char *username, const char *password);
 
         AFV_NATIVE_API void SetCallsign(std::string callsign);
-        AFV_NATIVE_API void SetCallsign(char *callsign);
+        AFV_NATIVE_API void SetCallsign(const char *callsign);
 
         AFV_NATIVE_API void SetClientPosition(double lat, double lon, double amslm, double aglm);
 
@@ -73,16 +74,16 @@ namespace afv_native::api {
         AFV_NATIVE_API void FreeAudioApis(char **apis);
 
         AFV_NATIVE_API void SetAudioInputDevice(std::string inputDevice);
-        AFV_NATIVE_API void SetAudioInputDevice(char *inputDevice);
+        AFV_NATIVE_API void SetAudioInputDevice(const char *inputDevice);
         AFV_NATIVE_API std::vector<AudioInterface> GetAudioInputDevices(unsigned int mAudioApi);
         AFV_NATIVE_API AudioInterfaceNative **GetAudioInputDevicesNative(unsigned int mAudioApi);
         AFV_NATIVE_API std::string GetDefaultAudioInputDevice(unsigned int mAudioApi);
         AFV_NATIVE_API const char *GetDefaultAudioInputDeviceNative(unsigned int mAudioApi);
 
         AFV_NATIVE_API void SetAudioOutputDevice(std::string outputDevice);
-        AFV_NATIVE_API void SetAudioOutputDevice(char *outputDevice);
+        AFV_NATIVE_API void SetAudioOutputDevice(const char *outputDevice);
         AFV_NATIVE_API void SetAudioSpeakersOutputDevice(std::string outputDevice);
-        AFV_NATIVE_API void SetAudioSpeakersOutputDevice(char *outputDevice);
+        AFV_NATIVE_API void SetAudioSpeakersOutputDevice(const char *outputDevice);
         AFV_NATIVE_API std::vector<AudioInterface> GetAudioOutputDevices(unsigned int mAudioApi);
         AFV_NATIVE_API AudioInterfaceNative **GetAudioOutputDevicesNative(unsigned int mAudioApi);
         AFV_NATIVE_API std::string GetDefaultAudioOutputDevice(unsigned int mAudioApi);
@@ -118,19 +119,19 @@ namespace afv_native::api {
 
         // Use this to set the current transceivers to the transceivers from this station, pulled from the AFV database, only one at a time can be active
         AFV_NATIVE_API void UseTransceiversFromStation(std::string station, unsigned int freq);
-        AFV_NATIVE_API void UseTransceiversFromStation(char *station, unsigned int freq);
+        AFV_NATIVE_API void UseTransceiversFromStation(const char *station, unsigned int freq);
 
         AFV_NATIVE_API void SetManualTransceivers(unsigned int freq, std::vector<afv_native::afv::dto::StationTransceiver> transceivers);
 
         AFV_NATIVE_API void FetchTransceiverInfo(std::string station);
-        AFV_NATIVE_API void FetchTransceiverInfo(char *station);
+        AFV_NATIVE_API void FetchTransceiverInfo(const char *station);
         AFV_NATIVE_API void FetchStationVccs(std::string station);
-        AFV_NATIVE_API void FetchStationVccs(char *station);
+        AFV_NATIVE_API void FetchStationVccs(const char *station);
         AFV_NATIVE_API void GetStation(std::string station);
-        AFV_NATIVE_API void GetStation(char *station);
+        AFV_NATIVE_API void GetStation(const char *station);
 
         AFV_NATIVE_API int GetTransceiverCountForStation(std::string station);
-        AFV_NATIVE_API int GetTransceiverCountForStation(char *station);
+        AFV_NATIVE_API int GetTransceiverCountForStation(const char *station);
         AFV_NATIVE_API int GetTransceiverCountForFrequency(unsigned int freq);
 
         AFV_NATIVE_API void SetPtt(bool pttState);
@@ -142,7 +143,7 @@ namespace afv_native::api {
         AFV_NATIVE_API bool IsAtisListening();
 
         AFV_NATIVE_API void StartAtisPlayback(std::string callsign, unsigned int freq);
-        AFV_NATIVE_API void StartAtisPlayback(char *callsign, unsigned int freq);
+        AFV_NATIVE_API void StartAtisPlayback(const char *callsign, unsigned int freq);
         AFV_NATIVE_API void StopAtisPlayback();
         AFV_NATIVE_API bool IsAtisPlayingBack();
 
@@ -159,7 +160,7 @@ namespace afv_native::api {
         AFV_NATIVE_API int GetPlaybackChannel(unsigned int freq);
 
         AFV_NATIVE_API bool AddFrequency(unsigned int freq, std::string stationName = "");
-        AFV_NATIVE_API bool AddFrequency(unsigned int freq, char *stationName);
+        AFV_NATIVE_API bool AddFrequency(unsigned int freq, const char *stationName);
         AFV_NATIVE_API void RemoveFrequency(unsigned int freq);
         AFV_NATIVE_API bool IsFrequencyActive(unsigned int freq);
         AFV_NATIVE_API std::map<unsigned int, SimpleAtcRadioState> getRadioState();
@@ -172,7 +173,7 @@ namespace afv_native::api {
         AFV_NATIVE_API void SetHardware(afv_native::HardwareType hardware);
 
         AFV_NATIVE_API void RaiseClientEvent(std::function<void(afv_native::ClientEventType, void *, void *)> callback);
-        AFV_NATIVE_API void RaiseClientEvent(void *handle, void (*callback)(afv_native::ClientEventType, void *, void *));
+        AFV_NATIVE_API void RaiseClientEvent(void *handle, void (*callback)(ClientEventType_t, void *, void *));
 
         //
         // Deprecated functions

--- a/src/atcClientFlat.cpp
+++ b/src/atcClientFlat.cpp
@@ -1,11 +1,10 @@
-#include "afv-native/atcClientFlat.h"
 #include "afv-native/atcClient.h"
 #include "afv-native/atcClientWrapper.h"
 
 struct ATCClientHandle_ {
     afv_native::api::atcClient *impl;
 
-    ATCClientHandle_(char *clientName, char *resourcePath, char *baseURL) {
+    ATCClientHandle_(const char *clientName, const char *resourcePath, const char *baseURL) {
         impl = new afv_native::api::atcClient(clientName, resourcePath, baseURL);
     }
 
@@ -16,7 +15,7 @@ struct ATCClientHandle_ {
     }
 };
 
-AFV_NATIVE_API ATCClientHandle ATCClient_Create(char *clientName, char *resourcePath, char *baseURL) {
+AFV_NATIVE_API ATCClientHandle ATCClient_Create(const char *clientName, const char *resourcePath, const char *baseURL) {
     return new ATCClientHandle_(clientName, resourcePath, baseURL);
 }
 
@@ -28,11 +27,11 @@ AFV_NATIVE_API bool ATCClient_IsInitialized(ATCClientHandle handle) {
     return handle->impl->IsInitialized();
 }
 
-AFV_NATIVE_API void ATCClient_SetCredentials(ATCClientHandle handle, char *username, char *password) {
+AFV_NATIVE_API void ATCClient_SetCredentials(ATCClientHandle handle, const char *username, const char *password) {
     handle->impl->SetCredentials(username, password);
 }
 
-AFV_NATIVE_API void ATCClient_SetCallsign(ATCClientHandle handle, char *callsign) {
+AFV_NATIVE_API void ATCClient_SetCallsign(ATCClientHandle handle, const char *callsign) {
     handle->impl->SetCallsign(callsign);
 }
 
@@ -74,7 +73,7 @@ AFV_NATIVE_API void ATCClient_FreeAudioApis(ATCClientHandle handle, char **apis)
     handle->impl->FreeAudioApis(apis);
 }
 
-AFV_NATIVE_API void ATCClient_SetAudioInputDevice(ATCClientHandle handle, char *inputDevice) {
+AFV_NATIVE_API void ATCClient_SetAudioInputDevice(ATCClientHandle handle, const char *inputDevice) {
     handle->impl->SetAudioInputDevice(inputDevice);
 }
 
@@ -91,11 +90,11 @@ AFV_NATIVE_API const char *ATCClient_GetDefaultAudioInputDevice(ATCClientHandle 
     return handle->impl->GetDefaultAudioInputDeviceNative(mAudioApi);
 }
 
-AFV_NATIVE_API void ATCClient_SetAudioOutputDevice(ATCClientHandle handle, char *outputDevice) {
+AFV_NATIVE_API void ATCClient_SetAudioOutputDevice(ATCClientHandle handle, const char *outputDevice) {
     handle->impl->SetAudioOutputDevice(outputDevice);
 }
 
-AFV_NATIVE_API void ATCClient_SetAudioSpeakersOutputDevice(ATCClientHandle handle, char *outputDevice) {
+AFV_NATIVE_API void ATCClient_SetAudioSpeakersOutputDevice(ATCClientHandle handle, const char *outputDevice) {
     handle->impl->SetAudioSpeakersOutputDevice(outputDevice);
 }
 
@@ -196,23 +195,23 @@ AFV_NATIVE_API bool ATCClient_GetCrossCoupleAcrossState(ATCClientHandle handle, 
     return handle->impl->GetCrossCoupleAcrossState(freq);
 }
 
-AFV_NATIVE_API void ATCClient_UseTransceiversFromStation(ATCClientHandle handle, char *station, unsigned int freq) {
+AFV_NATIVE_API void ATCClient_UseTransceiversFromStation(ATCClientHandle handle, const char *station, unsigned int freq) {
     handle->impl->UseTransceiversFromStation(station, freq);
 }
 
-AFV_NATIVE_API void ATCClient_FetchTransceiverInfo(ATCClientHandle handle, char *station) {
+AFV_NATIVE_API void ATCClient_FetchTransceiverInfo(ATCClientHandle handle, const char *station) {
     handle->impl->FetchTransceiverInfo(station);
 }
 
-AFV_NATIVE_API void ATCClient_FetchStationVccs(ATCClientHandle handle, char *station) {
+AFV_NATIVE_API void ATCClient_FetchStationVccs(ATCClientHandle handle, const char *station) {
     handle->impl->FetchStationVccs(station);
 }
 
-AFV_NATIVE_API void ATCClient_GetStation(ATCClientHandle handle, char *station) {
+AFV_NATIVE_API void ATCClient_GetStation(ATCClientHandle handle, const char *station) {
     handle->impl->GetStation(station);
 }
 
-AFV_NATIVE_API int ATCClient_GetTransceiverCountForStation(ATCClientHandle handle, char *station) {
+AFV_NATIVE_API int ATCClient_GetTransceiverCountForStation(ATCClientHandle handle, const char *station) {
     return handle->impl->GetTransceiverCountForStation(station);
 }
 
@@ -248,7 +247,7 @@ AFV_NATIVE_API int ATCClient_GetPlaybackChannel(ATCClientHandle handle, unsigned
     return handle->impl->GetPlaybackChannel(freq);
 }
 
-AFV_NATIVE_API bool ATCClient_AddFrequency(ATCClientHandle handle, unsigned int freq, char *stationName) {
+AFV_NATIVE_API bool ATCClient_AddFrequency(ATCClientHandle handle, unsigned int freq, const char *stationName) {
     return handle->impl->AddFrequency(freq, stationName);
 }
 
@@ -278,11 +277,11 @@ AFV_NATIVE_API void ATCClient_FreeString(ATCClientHandle handle, char *in) {
     handle->impl->FreeString(in);
 }
 
-AFV_NATIVE_API void ATCClient_SetHardware(ATCClientHandle handle, afv_native::HardwareType hardware) {
-    handle->impl->SetHardware(hardware);
+AFV_NATIVE_API void ATCClient_SetHardware(ATCClientHandle handle, HardwareType_t hardware) {
+    handle->impl->SetHardware(static_cast<afv_native::HardwareType>(hardware));
 }
 
-AFV_NATIVE_API void ATCClient_RaiseClientEvent(ATCClientHandle handle, void (*callback)(afv_native::ClientEventType, void *, void *)) {
+AFV_NATIVE_API void ATCClient_RaiseClientEvent(ATCClientHandle handle, void (*callback)(ClientEventType_t, void *, void *)) {
     handle->impl->RaiseClientEvent(handle, callback);
 }
 

--- a/src/atcClientWrapper.cpp
+++ b/src/atcClientWrapper.cpp
@@ -3,6 +3,7 @@
 #include "afv-native/afv/ATCRadioSimulation.h"
 #include "afv-native/afv/dto/StationTransceiver.h"
 #include "afv-native/atcClient.h"
+#include "afv-native/atcClientFlat.h"
 #include "afv-native/hardwareType.h"
 #include <algorithm>
 #include <atomic>
@@ -78,7 +79,7 @@ afv_native::api::atcClient::atcClient(std::string clientName, std::string resour
     isInitialized = true;
 }
 
-afv_native::api::atcClient::atcClient(char *clientName, char *resourcePath, char *baseURL):
+afv_native::api::atcClient::atcClient(const char *clientName, const char *resourcePath, const char *baseURL):
     atcClient(std::string(clientName), std::string(resourcePath), std::string(baseURL)) {
 }
 
@@ -104,7 +105,7 @@ void afv_native::api::atcClient::SetCredentials(std::string username, std::strin
     client->setCredentials(std::string(username), std::string(password));
 }
 
-void afv_native::api::atcClient::SetCredentials(char *username, char *password) {
+void afv_native::api::atcClient::SetCredentials(const char *username, const char *password) {
     SetCredentials(std::string(username), std::string(password));
 }
 
@@ -113,7 +114,7 @@ void afv_native::api::atcClient::SetCallsign(std::string callsign) {
     client->setCallsign(std::string(callsign));
 }
 
-void afv_native::api::atcClient::SetCallsign(char *callsign) {
+void afv_native::api::atcClient::SetCallsign(const char *callsign) {
     SetCallsign(std::string(callsign));
 }
 
@@ -170,7 +171,7 @@ void afv_native::api::atcClient::SetAudioInputDevice(std::string inputDevice) {
     client->setAudioInputDevice(inputDevice);
 }
 
-void afv_native::api::atcClient::SetAudioInputDevice(char *inputDevice) {
+void afv_native::api::atcClient::SetAudioInputDevice(const char *inputDevice) {
     SetAudioInputDevice(std::string(inputDevice));
 }
 
@@ -179,7 +180,7 @@ void afv_native::api::atcClient::SetAudioOutputDevice(std::string outputDevice) 
     client->setAudioOutputDevice(outputDevice);
 }
 
-void afv_native::api::atcClient::SetAudioOutputDevice(char *outputDevice) {
+void afv_native::api::atcClient::SetAudioOutputDevice(const char *outputDevice) {
     SetAudioOutputDevice(std::string(outputDevice));
 }
 
@@ -188,7 +189,7 @@ void afv_native::api::atcClient::SetAudioSpeakersOutputDevice(std::string output
     client->setSpeakerOutputDevice(outputDevice);
 }
 
-void afv_native::api::atcClient::SetAudioSpeakersOutputDevice(char *outputDevice) {
+void afv_native::api::atcClient::SetAudioSpeakersOutputDevice(const char *outputDevice) {
     SetAudioSpeakersOutputDevice(std::string(outputDevice));
 }
 
@@ -382,7 +383,7 @@ void afv_native::api::atcClient::UseTransceiversFromStation(std::string station,
     client->linkTransceivers(station, freq);
 };
 
-void afv_native::api::atcClient::UseTransceiversFromStation(char *station, unsigned int freq) {
+void afv_native::api::atcClient::UseTransceiversFromStation(const char *station, unsigned int freq) {
     UseTransceiversFromStation(std::string(station), freq);
 }
 
@@ -394,7 +395,7 @@ int afv_native::api::atcClient::GetTransceiverCountForStation(std::string statio
     return 0;
 };
 
-int afv_native::api::atcClient::GetTransceiverCountForStation(char *station) {
+int afv_native::api::atcClient::GetTransceiverCountForStation(const char *station) {
     return GetTransceiverCountForStation(std::string(station));
 }
 
@@ -406,7 +407,7 @@ void afv_native::api::atcClient::FetchTransceiverInfo(std::string station) {
     client->requestStationTransceivers(station);
 }
 
-void afv_native::api::atcClient::FetchTransceiverInfo(char *station) {
+void afv_native::api::atcClient::FetchTransceiverInfo(const char *station) {
     FetchTransceiverInfo(std::string(station));
 }
 
@@ -414,7 +415,7 @@ void afv_native::api::atcClient::GetStation(std::string station) {
     client->getStation(station);
 }
 
-void afv_native::api::atcClient::GetStation(char *station) {
+void afv_native::api::atcClient::GetStation(const char *station) {
     GetStation(std::string(station));
 }
 
@@ -422,7 +423,7 @@ void afv_native::api::atcClient::FetchStationVccs(std::string station) {
     client->requestStationVccs(station);
 }
 
-void afv_native::api::atcClient::FetchStationVccs(char *station) {
+void afv_native::api::atcClient::FetchStationVccs(const char *station) {
     FetchStationVccs(std::string(station));
 }
 
@@ -444,7 +445,7 @@ bool afv_native::api::atcClient::AddFrequency(unsigned int freq, std::string sta
     return client->addFrequency(freq, true, stationName);
 }
 
-bool afv_native::api::atcClient::AddFrequency(unsigned int freq, char *stationName) {
+bool afv_native::api::atcClient::AddFrequency(unsigned int freq, const char *stationName) {
     return AddFrequency(freq, std::string(stationName));
 }
 
@@ -480,7 +481,7 @@ void afv_native::api::atcClient::StartAtisPlayback(std::string callsign, unsigne
     client->startAtisPlayback(callsign, freq);
 }
 
-void afv_native::api::atcClient::StartAtisPlayback(char *callsign, unsigned int freq) {
+void afv_native::api::atcClient::StartAtisPlayback(const char *callsign, unsigned int freq) {
     StartAtisPlayback(std::string(callsign), freq);
 }
 
@@ -505,9 +506,11 @@ void afv_native::api::atcClient::RaiseClientEvent(std::function<void(afv_native:
     });
 }
 
-void afv_native::api::atcClient::RaiseClientEvent(void *handle, void (*callback)(afv_native::ClientEventType, void *, void *)) {
+void afv_native::api::atcClient::RaiseClientEvent(void *handle, void (*callback)(ClientEventType_t, void *, void *)) {
     std::lock_guard<std::mutex> lock(afvMutex);
-    client->ClientEventCallback.addCallback(handle, std::function(callback));
+    client->ClientEventCallback.addCallback(handle, [callback](afv_native::ClientEventType evt, void *data, void *data2) {
+        callback(static_cast<ClientEventType_t>(evt), data, data2);
+    });
 }
 
 AFV_NATIVE_API void afv_native::api::atcClient::SetRadioGainAll(float gain) {


### PR DESCRIPTION
- Some programs designed to generate bindings to a C API aren't tolerant of any C++ headers being included. As such I removed all references to other afv-native headers from atcClientFlat.h, creating new typedefs as required for enums that were being used.
- Improve the const-correctness of string pointers in the flat and wrapper clients. String literals should be const char*.
- Modify cmake to allow for a different vcpkg root, rather than using the vendored version that comes with this project. (This change can be removed, I needed it because vendored vcpkg doesn't really play well with NixOS)

Typedef enums added to atcClientFlat.h were copy pasted from their C++ equivalent, as such they can be converted at boundaries between the two APIs with static_cast.