### PR TITLE
Add No_Hardware as HardwareType to disable radio audio effects

### DIFF
--- a/include/afv-native/atcClientFlat.h
+++ b/include/afv-native/atcClientFlat.h
@@ -30,7 +30,8 @@ struct AFV_NATIVE_API AudioInterfaceNative {
     enum class HardwareType {
         Schmid_ED_137B,
         Rockwell_Collins_2100,
-        Garex_220
+        Garex_220,
+        No_Hardware
     };
 
     enum class PlaybackChannel {

--- a/include/afv-native/hardwareType.h
+++ b/include/afv-native/hardwareType.h
@@ -5,7 +5,8 @@ namespace afv_native {
     enum class HardwareType {
         Schmid_ED_137B,
         Rockwell_Collins_2100,
-        Garex_220
+        Garex_220,
+        No_Hardware
     };
 
     enum class PlaybackChannel {


### PR DESCRIPTION
This pull requests add the HardwareType "No_Hardware" to the HardwareType enum in the hardwareType.h, to make it possible to disable radio affects in TrackAudio.

This pull request shall implement the issue: https://github.com/pierr3/TrackAudio/issues/156