### PR TITLE
Fix thread safety in Request::reset: lock CURLM access

### DIFF
--- a/include/afv-native/http/TransferManager.h
+++ b/include/afv-native/http/TransferManager.h
@@ -97,6 +97,12 @@ namespace afv_native { namespace http {
          * handle, registers the callback, and wakes the poll thread. */
         void submitRequest(Request *req);
 
+        /** Thread-safe request cancellation. Acquires the CURLM lock, removes
+         * the easy handle from the multi handle, and deregisters the callback.
+         * Safe to call from any thread, including while the poll thread is
+         * inside curl_multi_perform / curl_multi_poll. */
+        void cancelRequest(Request *req);
+
         virtual ~TransferManager();
 
         /** Process any outstanding events without blocking. */

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -55,8 +55,7 @@ Request::~Request() {
 void Request::reset() {
     if (mCurlHandle) {
         if (mTM != nullptr) {
-            curl_multi_remove_handle(mTM->getCurlMultiHandle(), mCurlHandle.get());
-            mTM->removeAsyncCallback(*this);
+            mTM->cancelRequest(this);
             mTM = nullptr;
         }
         mCurlHandle.reset();
@@ -303,6 +302,7 @@ bool Request::doAsync(TransferManager &transferManager) {
         return false;
     }
 
+    shareState(transferManager);
     transferManager.submitRequest(this);
     mTM = &transferManager;
     return true;

--- a/src/http/TransferManager.cpp
+++ b/src/http/TransferManager.cpp
@@ -118,6 +118,18 @@ void TransferManager::submitRequest(Request *req) {
     }
 }
 
+void TransferManager::cancelRequest(Request *req) {
+    if (!req) {
+        return;
+    }
+    std::lock_guard<std::recursive_mutex> lock(mMutex);
+    auto h = req->getCurlHandle();
+    if (h) {
+        curl_multi_remove_handle(mCurlMultiHandle.get(), h);
+        mPendingTransfers.erase(h);
+    }
+}
+
 CURLM *TransferManager::getCurlMultiHandle() const {
     return mCurlMultiHandle.get();
 }


### PR DESCRIPTION
Had some crashes with access violations inside libcurl.dll
Request:resset called curl_multi_remove_handle on the CURLM handle without holding the TransferManager mutex

To fix the race condition:
TransferManager now has cancelRequest that acquires the mutex before doing the calls

I ran a session over 60 minutes and had no issues left after this fix