### PR TITLE
Fix hung token refresh stranding the session in Reconnecting

### DIFF
--- a/include/afv-native/afv/APISession.h
+++ b/include/afv-native/afv/APISession.h
@@ -42,7 +42,6 @@
 #include "afv-native/http/Request.h"
 #include "afv-native/http/TransferManager.h"
 #include "afv-native/util/ChainedCallback.h"
-#include <ctime>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -92,16 +91,6 @@ namespace afv_native { namespace afv {
         util::ChainedCallback<void(bool, std::pair<std::string, dto::Station>)> StationSearchCallback;
 
       protected:
-        // Backstop for an auth request that never reports completion at all.
-        // Longer than the request's own timeout so the error path wins normally.
-        static constexpr unsigned int kAuthWatchdogMs = 45 * 1000;
-
-        static constexpr unsigned int kRefreshRetryBaseMs = 5 * 1000;
-        static constexpr unsigned int kRefreshRetryMaxMs  = 30 * 1000;
-
-        // Below this much life left, stop retrying and fail the session properly.
-        static constexpr int kRefreshGiveUpMarginSeconds = 5;
-
         void _authenticationCallback(http::RESTRequest *req, bool success);
         void _stationsCallback(http::RESTRequest *req, bool success);
         void _stationTransceiversCallback(http::RESTRequest *req, bool success, std::string stationName);
@@ -117,14 +106,6 @@ namespace afv_native { namespace afv {
         std::string            mClientName;
 
         std::string mBearerToken;
-
-        // Wall-clock expiry of mBearerToken, or 0 when there is none.
-        std::time_t  mTokenExpiryTime;
-        unsigned int mRefreshFailureCount;
-
-        // Set between dispatching an auth request and its callback firing. Still
-        // set on entry to Connect() means the previous one was lost outright.
-        bool mAuthRequestInFlight;
 
         http::RESTRequest mAuthenticationRequest;
 

--- a/include/afv-native/afv/APISession.h
+++ b/include/afv-native/afv/APISession.h
@@ -42,6 +42,7 @@
 #include "afv-native/http/Request.h"
 #include "afv-native/http/TransferManager.h"
 #include "afv-native/util/ChainedCallback.h"
+#include <ctime>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -91,6 +92,16 @@ namespace afv_native { namespace afv {
         util::ChainedCallback<void(bool, std::pair<std::string, dto::Station>)> StationSearchCallback;
 
       protected:
+        // Backstop for an auth request that never reports completion at all.
+        // Longer than the request's own timeout so the error path wins normally.
+        static constexpr unsigned int kAuthWatchdogMs = 45 * 1000;
+
+        static constexpr unsigned int kRefreshRetryBaseMs = 5 * 1000;
+        static constexpr unsigned int kRefreshRetryMaxMs  = 30 * 1000;
+
+        // Below this much life left, stop retrying and fail the session properly.
+        static constexpr int kRefreshGiveUpMarginSeconds = 5;
+
         void _authenticationCallback(http::RESTRequest *req, bool success);
         void _stationsCallback(http::RESTRequest *req, bool success);
         void _stationTransceiversCallback(http::RESTRequest *req, bool success, std::string stationName);
@@ -106,6 +117,14 @@ namespace afv_native { namespace afv {
         std::string            mClientName;
 
         std::string mBearerToken;
+
+        // Wall-clock expiry of mBearerToken, or 0 when there is none.
+        std::time_t  mTokenExpiryTime;
+        unsigned int mRefreshFailureCount;
+
+        // Set between dispatching an auth request and its callback firing. Still
+        // set on entry to Connect() means the previous one was lost outright.
+        bool mAuthRequestInFlight;
 
         http::RESTRequest mAuthenticationRequest;
 

--- a/include/afv-native/http/Request.h
+++ b/include/afv-native/http/Request.h
@@ -93,9 +93,17 @@ namespace afv_native { namespace http {
 
         bool mResponseInfoCaptured;
 
+        long mConnectTimeoutSeconds;
+        long mTransferTimeoutSeconds;
+
         virtual bool setupHandle();
 
       public:
+        // Every request here is a small REST call, so a transfer still running
+        // after this long is wedged rather than slow.
+        static constexpr long kDefaultConnectTimeoutSeconds  = 10;
+        static constexpr long kDefaultTransferTimeoutSeconds = 30;
+
         Request(const std::string &url, Method method);
         /* no copy constructor - Request must not be copied as it would break the internal states. */
         Request(const Request &cpysrc) = delete;
@@ -133,6 +141,11 @@ namespace afv_native { namespace http {
         void setCompletionCallback(std::function<void(Request *, bool)> cb);
 
         void setFollowRedirect(bool follow);
+
+        /** Overrides the default timeouts.  Applied on the next doSync/doAsync.
+         * A value of 0 disables that timeout.
+         */
+        void setTimeouts(long connectTimeoutSeconds, long transferTimeoutSeconds);
 
         void shareState(TransferManager &transferManager);
 

--- a/include/afv-native/http/TransferManager.h
+++ b/include/afv-native/http/TransferManager.h
@@ -61,6 +61,26 @@ namespace afv_native { namespace http {
      */
     class TransferManager {
       protected:
+        /** Refcounted curl_global_init/curl_global_cleanup.
+         *
+         * libcurl will initialise itself lazily from curl_easy_init if this is
+         * never called, but that path is explicitly not thread safe, and we
+         * create requests from the poll thread, the session timer threads and
+         * the caller's thread.  Doing it here covers every entry point without
+         * adding an init call to the public API - and doing it from a member
+         * declared first means it runs before curl_multi_init below and is
+         * torn down after both handles are gone.
+         */
+        class CurlGlobalGuard {
+          public:
+            CurlGlobalGuard();
+            ~CurlGlobalGuard();
+            CurlGlobalGuard(const CurlGlobalGuard &)            = delete;
+            CurlGlobalGuard &operator=(const CurlGlobalGuard &) = delete;
+        };
+
+        CurlGlobalGuard mCurlGlobalGuard;
+
         /** Per-datum locks for the share handle.  libcurl requires these
          * whenever a share is used from more than one thread, which it is here:
          * easy handles are created and destroyed on session timer threads while

--- a/include/afv-native/http/TransferManager.h
+++ b/include/afv-native/http/TransferManager.h
@@ -34,6 +34,7 @@
 #ifndef AFV_NATIVE_TRANSFERMANAGER_H
 #define AFV_NATIVE_TRANSFERMANAGER_H
 
+#include <array>
 #include <curl/curl.h>
 #include <memory>
 #include <mutex>
@@ -60,6 +61,16 @@ namespace afv_native { namespace http {
      */
     class TransferManager {
       protected:
+        /** Per-datum locks for the share handle.  libcurl requires these
+         * whenever a share is used from more than one thread, which it is here:
+         * easy handles are created and destroyed on session timer threads while
+         * the poll thread is inside curl_multi_perform.
+         *
+         * Must be declared before the handles below - curl_share_cleanup calls
+         * back into these, and members die in reverse declaration order.
+         */
+        std::array<std::mutex, CURL_LOCK_DATA_LAST> mShareLocks;
+
         std::unique_ptr<CURLM, CurlMultiDeleter>  mCurlMultiHandle;
         std::unique_ptr<CURLSH, CurlShareDeleter> mCurlShareHandle;
 
@@ -77,6 +88,9 @@ namespace afv_native { namespace http {
         std::unordered_set<Request *> mCancelledDuringDispatch;
 
         std::recursive_mutex mMutex;
+
+        static void curlShareLock(CURL *handle, curl_lock_data data, curl_lock_access access, void *userptr);
+        static void curlShareUnlock(CURL *handle, curl_lock_data data, void *userptr);
 
         /** Returns true (and forgets the tombstone) if the request was
          * cancelled since the start of the current dispatch cycle. */

--- a/src/afv/APISession.cpp
+++ b/src/afv/APISession.cpp
@@ -37,7 +37,6 @@
 #include "afv-native/afv/dto/PostCallsignResponse.h"
 #include "afv-native/afv/params.h"
 #include "afv-native/http/RESTRequest.h"
-#include <algorithm>
 #include <functional>
 #include <jwt/jwt.hpp>
 #include <memory>
@@ -49,9 +48,10 @@ using namespace ::afv_native;
 using json = nlohmann::json;
 
 APISession::APISession(http::TransferManager &tm, std::string baseUrl, std::string clientName):
-    StateCallback(), AliasUpdateCallback(), mTransferManager(tm), mBaseURL(std::move(baseUrl)), mUsername(), mPassword(), mClientName(std::move(clientName)), mBearerToken(), mTokenExpiryTime(0), mRefreshFailureCount(0), mAuthRequestInFlight(false), mAuthenticationRequest(mBaseURL + "/api/v1/auth", http::Method::POST, json()), mRefreshTokenTimer(std::bind(&APISession::Connect, this)), mLastError(APISessionError::NoError), mStationAliasRequest(mBaseURL + "/api/v1/stations/aliased", http::Method::GET, nullptr), mState(APISessionState::Disconnected), mStationTransceiversRequest(mBaseURL, http::Method::GET, nullptr), StationTransceiversUpdateCallback(), StationVccsCallback(), StationSearchCallback(), mGetStationRequest(mBaseURL, http::Method::GET, nullptr), mVccsRequest(mBaseURL, http::Method::GET, nullptr) {
-    // Tighter than the default: the refresh only has 60s of runway before the
-    // live token dies, so failing fast leaves room for retries.
+    StateCallback(), AliasUpdateCallback(), mTransferManager(tm), mBaseURL(std::move(baseUrl)), mUsername(), mPassword(), mClientName(std::move(clientName)), mBearerToken(), mAuthenticationRequest(mBaseURL + "/api/v1/auth", http::Method::POST, json()), mRefreshTokenTimer(std::bind(&APISession::Connect, this)), mLastError(APISessionError::NoError), mStationAliasRequest(mBaseURL + "/api/v1/stations/aliased", http::Method::GET, nullptr), mState(APISessionState::Disconnected), mStationTransceiversRequest(mBaseURL, http::Method::GET, nullptr), StationTransceiversUpdateCallback(), StationVccsCallback(), StationSearchCallback(), mGetStationRequest(mBaseURL, http::Method::GET, nullptr), mVccsRequest(mBaseURL, http::Method::GET, nullptr) {
+    // Tighter than the default: the token refresh is scheduled 60s before the
+    // live token expires, so this request has to fail well inside that window
+    // for the error to be reportable while the session is still usable.
     mAuthenticationRequest.setTimeouts(5, 15);
 }
 
@@ -68,14 +68,6 @@ void APISession::Connect() {
         this->_authenticationCallback(restreq, success);
     });
     mAuthenticationRequest.shareState(mTransferManager);
-    if (mAuthRequestInFlight) {
-        LOG("APISession",
-            "previous auth request never reported completion - reissuing via watchdog");
-    }
-    mAuthRequestInFlight = true;
-    // Armed before dispatch so the callback, which can only run afterwards,
-    // always overwrites it. Guarantees a timer is always pending.
-    mRefreshTokenTimer.enable(kAuthWatchdogMs);
     mAuthenticationRequest.doAsync(mTransferManager);
     /* update our internal state */
     switch (mState) {
@@ -92,10 +84,7 @@ void APISession::Connect() {
 
 void afv::APISession::Disconnect() {
     mRefreshTokenTimer.disable();
-    mBearerToken         = "";
-    mTokenExpiryTime     = 0;
-    mRefreshFailureCount = 0;
-    mAuthRequestInFlight = false;
+    mBearerToken = "";
     mAuthenticationRequest.reset();
     setState(APISessionState::Disconnected);
 }
@@ -113,10 +102,6 @@ void APISession::setPassword(const std::string &password) {
 }
 
 void APISession::_authenticationCallback(http::RESTRequest *req, bool success) {
-    mAuthRequestInFlight = false;
-    // Cancel the watchdog; every branch below either re-arms it or is terminal.
-    mRefreshTokenTimer.disable();
-
     if (success && req->getStatusCode() == 200) {
         mBearerToken = req->getResponseBody();
         if (mBearerToken.empty()) {
@@ -145,12 +130,10 @@ void APISession::_authenticationCallback(http::RESTRequest *req, bool success) {
                         raiseError(APISessionError::AuthTokenExpiryTimeInPast);
                         return;
                     }
-                    mTokenExpiryTime = expiry;
                     LOG("APISession", "API Token Expires in %d seconds", expiry - time(nullptr));
                     // refresh 1 minute before token expiry.
                     mRefreshTokenTimer.enable((timeRemaining - 60) * 1000);
                 } else {
-                    mTokenExpiryTime = ::time(nullptr) + (60 * 60);
                     LOG("APISession", "no expiry claim - assuming 1 hour.",
                         ec.message().c_str());
                     mRefreshTokenTimer.enable(59 * 60 * 1000); // refresh in 59 minutes.
@@ -163,44 +146,11 @@ void APISession::_authenticationCallback(http::RESTRequest *req, bool success) {
             raiseError(APISessionError::InvalidAuthToken);
             return;
         }
-        mRefreshFailureCount = 0;
         setState(APISessionState::Running);
     } else {
-        // A failed refresh is not a failed login: the session is live and the
-        // old token may still have time on it, so retry while it can carry us
-        // rather than dropping a controller off frequency over a transient blip.
-        if (mState == APISessionState::Reconnecting && !mBearerToken.empty()) {
-            const int remaining = static_cast<int>(mTokenExpiryTime - ::time(nullptr));
-            if (remaining > kRefreshGiveUpMarginSeconds) {
-                const std::string reason =
-                    success ? ("HTTP " + std::to_string(req->getStatusCode()))
-                            : std::string(req->getCurlError());
-
-                mRefreshFailureCount++;
-                unsigned int delayMs =
-                    kRefreshRetryBaseMs * (1u << std::min(mRefreshFailureCount - 1u, 3u));
-                delayMs = std::min(delayMs, kRefreshRetryMaxMs);
-                // Never sleep past the point where the token dies under us.
-                delayMs = std::min(delayMs,
-                                   static_cast<unsigned int>(remaining - kRefreshGiveUpMarginSeconds) * 1000u);
-                delayMs = std::max(delayMs, 1000u);
-
-                LOG("APISession",
-                    "token refresh attempt %u failed (%s) - retrying in %ums, current token valid for %ds",
-                    mRefreshFailureCount, reason.c_str(), delayMs, remaining);
-
-                mAuthenticationRequest.reset();
-                mRefreshTokenTimer.enable(delayMs);
-                return;
-            }
-            LOG("APISession",
-                "token refresh failed and the current token has expired - failing the session");
-        }
-
         // This is a failure during auth, which is grounds to handle it as
         // if it were an immediate disconnect.
-        mBearerToken     = "";
-        mTokenExpiryTime = 0;
+        mBearerToken = "";
         if (!success) {
             LOG("APISession", "curl internal error during login: %s",
                 req->getCurlError().c_str());

--- a/src/afv/APISession.cpp
+++ b/src/afv/APISession.cpp
@@ -37,6 +37,7 @@
 #include "afv-native/afv/dto/PostCallsignResponse.h"
 #include "afv-native/afv/params.h"
 #include "afv-native/http/RESTRequest.h"
+#include <algorithm>
 #include <functional>
 #include <jwt/jwt.hpp>
 #include <memory>
@@ -48,7 +49,10 @@ using namespace ::afv_native;
 using json = nlohmann::json;
 
 APISession::APISession(http::TransferManager &tm, std::string baseUrl, std::string clientName):
-    StateCallback(), AliasUpdateCallback(), mTransferManager(tm), mBaseURL(std::move(baseUrl)), mUsername(), mPassword(), mClientName(std::move(clientName)), mBearerToken(), mAuthenticationRequest(mBaseURL + "/api/v1/auth", http::Method::POST, json()), mRefreshTokenTimer(std::bind(&APISession::Connect, this)), mLastError(APISessionError::NoError), mStationAliasRequest(mBaseURL + "/api/v1/stations/aliased", http::Method::GET, nullptr), mState(APISessionState::Disconnected), mStationTransceiversRequest(mBaseURL, http::Method::GET, nullptr), StationTransceiversUpdateCallback(), StationVccsCallback(), StationSearchCallback(), mGetStationRequest(mBaseURL, http::Method::GET, nullptr), mVccsRequest(mBaseURL, http::Method::GET, nullptr) {
+    StateCallback(), AliasUpdateCallback(), mTransferManager(tm), mBaseURL(std::move(baseUrl)), mUsername(), mPassword(), mClientName(std::move(clientName)), mBearerToken(), mTokenExpiryTime(0), mRefreshFailureCount(0), mAuthRequestInFlight(false), mAuthenticationRequest(mBaseURL + "/api/v1/auth", http::Method::POST, json()), mRefreshTokenTimer(std::bind(&APISession::Connect, this)), mLastError(APISessionError::NoError), mStationAliasRequest(mBaseURL + "/api/v1/stations/aliased", http::Method::GET, nullptr), mState(APISessionState::Disconnected), mStationTransceiversRequest(mBaseURL, http::Method::GET, nullptr), StationTransceiversUpdateCallback(), StationVccsCallback(), StationSearchCallback(), mGetStationRequest(mBaseURL, http::Method::GET, nullptr), mVccsRequest(mBaseURL, http::Method::GET, nullptr) {
+    // Tighter than the default: the refresh only has 60s of runway before the
+    // live token dies, so failing fast leaves room for retries.
+    mAuthenticationRequest.setTimeouts(5, 15);
 }
 
 void APISession::Connect() {
@@ -64,6 +68,14 @@ void APISession::Connect() {
         this->_authenticationCallback(restreq, success);
     });
     mAuthenticationRequest.shareState(mTransferManager);
+    if (mAuthRequestInFlight) {
+        LOG("APISession",
+            "previous auth request never reported completion - reissuing via watchdog");
+    }
+    mAuthRequestInFlight = true;
+    // Armed before dispatch so the callback, which can only run afterwards,
+    // always overwrites it. Guarantees a timer is always pending.
+    mRefreshTokenTimer.enable(kAuthWatchdogMs);
     mAuthenticationRequest.doAsync(mTransferManager);
     /* update our internal state */
     switch (mState) {
@@ -80,7 +92,10 @@ void APISession::Connect() {
 
 void afv::APISession::Disconnect() {
     mRefreshTokenTimer.disable();
-    mBearerToken = "";
+    mBearerToken         = "";
+    mTokenExpiryTime     = 0;
+    mRefreshFailureCount = 0;
+    mAuthRequestInFlight = false;
     mAuthenticationRequest.reset();
     setState(APISessionState::Disconnected);
 }
@@ -98,6 +113,10 @@ void APISession::setPassword(const std::string &password) {
 }
 
 void APISession::_authenticationCallback(http::RESTRequest *req, bool success) {
+    mAuthRequestInFlight = false;
+    // Cancel the watchdog; every branch below either re-arms it or is terminal.
+    mRefreshTokenTimer.disable();
+
     if (success && req->getStatusCode() == 200) {
         mBearerToken = req->getResponseBody();
         if (mBearerToken.empty()) {
@@ -126,10 +145,12 @@ void APISession::_authenticationCallback(http::RESTRequest *req, bool success) {
                         raiseError(APISessionError::AuthTokenExpiryTimeInPast);
                         return;
                     }
+                    mTokenExpiryTime = expiry;
                     LOG("APISession", "API Token Expires in %d seconds", expiry - time(nullptr));
                     // refresh 1 minute before token expiry.
                     mRefreshTokenTimer.enable((timeRemaining - 60) * 1000);
                 } else {
+                    mTokenExpiryTime = ::time(nullptr) + (60 * 60);
                     LOG("APISession", "no expiry claim - assuming 1 hour.",
                         ec.message().c_str());
                     mRefreshTokenTimer.enable(59 * 60 * 1000); // refresh in 59 minutes.
@@ -142,11 +163,44 @@ void APISession::_authenticationCallback(http::RESTRequest *req, bool success) {
             raiseError(APISessionError::InvalidAuthToken);
             return;
         }
+        mRefreshFailureCount = 0;
         setState(APISessionState::Running);
     } else {
+        // A failed refresh is not a failed login: the session is live and the
+        // old token may still have time on it, so retry while it can carry us
+        // rather than dropping a controller off frequency over a transient blip.
+        if (mState == APISessionState::Reconnecting && !mBearerToken.empty()) {
+            const int remaining = static_cast<int>(mTokenExpiryTime - ::time(nullptr));
+            if (remaining > kRefreshGiveUpMarginSeconds) {
+                const std::string reason =
+                    success ? ("HTTP " + std::to_string(req->getStatusCode()))
+                            : std::string(req->getCurlError());
+
+                mRefreshFailureCount++;
+                unsigned int delayMs =
+                    kRefreshRetryBaseMs * (1u << std::min(mRefreshFailureCount - 1u, 3u));
+                delayMs = std::min(delayMs, kRefreshRetryMaxMs);
+                // Never sleep past the point where the token dies under us.
+                delayMs = std::min(delayMs,
+                                   static_cast<unsigned int>(remaining - kRefreshGiveUpMarginSeconds) * 1000u);
+                delayMs = std::max(delayMs, 1000u);
+
+                LOG("APISession",
+                    "token refresh attempt %u failed (%s) - retrying in %ums, current token valid for %ds",
+                    mRefreshFailureCount, reason.c_str(), delayMs, remaining);
+
+                mAuthenticationRequest.reset();
+                mRefreshTokenTimer.enable(delayMs);
+                return;
+            }
+            LOG("APISession",
+                "token refresh failed and the current token has expired - failing the session");
+        }
+
         // This is a failure during auth, which is grounds to handle it as
         // if it were an immediate disconnect.
-        mBearerToken = "";
+        mBearerToken     = "";
+        mTokenExpiryTime = 0;
         if (!success) {
             LOG("APISession", "curl internal error during login: %s",
                 req->getCurlError().c_str());

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -44,7 +44,7 @@ using namespace std;
 using json = nlohmann::json;
 
 Request::Request(const string &url, Method method):
-    mMethod(method), mURL(url), mFollowRedirect(method == Method::GET), mProgress(Progress::New), mCurlHandle(), mHeaders(), mTM(nullptr), mReq(), mReqBufOffset(0), mRespStatusCode(0), mRespContentType(), mResp(), mCurlErrorBuffer(), mCompletionCallback(), mResponseInfoCaptured(false), mDownloadTotal(0), mDownloadProgress(0), mUploadTotal(0), mUploadProgress(0) {
+    mMethod(method), mURL(url), mFollowRedirect(method == Method::GET), mProgress(Progress::New), mCurlHandle(), mHeaders(), mTM(nullptr), mReq(), mReqBufOffset(0), mRespStatusCode(0), mRespContentType(), mResp(), mCurlErrorBuffer(), mCompletionCallback(), mResponseInfoCaptured(false), mConnectTimeoutSeconds(kDefaultConnectTimeoutSeconds), mTransferTimeoutSeconds(kDefaultTransferTimeoutSeconds), mDownloadTotal(0), mDownloadProgress(0), mUploadTotal(0), mUploadProgress(0) {
     mCurlErrorBuffer.fill(0);
 }
 
@@ -87,6 +87,11 @@ bool Request::setupHandle() {
         curl_easy_setopt(mCurlHandle.get(), CURLOPT_HTTPHEADER, mHeaders.get());
     }
 
+    /* Without these a stalled transfer never completes, so curl never queues a
+     * CURLMSG_DONE and the completion callback never runs. */
+    curl_easy_setopt(mCurlHandle.get(), CURLOPT_CONNECTTIMEOUT, mConnectTimeoutSeconds);
+    curl_easy_setopt(mCurlHandle.get(), CURLOPT_TIMEOUT, mTransferTimeoutSeconds);
+
     /* Disable Nagle because Mac says so.... */
     curl_easy_setopt(mCurlHandle.get(), CURLOPT_TCP_NODELAY, 1);
 
@@ -119,6 +124,11 @@ bool Request::setupHandle() {
 
 void Request::setFollowRedirect(bool follow) {
     mFollowRedirect = follow;
+}
+
+void Request::setTimeouts(long connectTimeoutSeconds, long transferTimeoutSeconds) {
+    mConnectTimeoutSeconds  = connectTimeoutSeconds;
+    mTransferTimeoutSeconds = transferTimeoutSeconds;
 }
 
 void Request::setHeader(const std::string &header, const std::string &value) {

--- a/src/http/TransferManager.cpp
+++ b/src/http/TransferManager.cpp
@@ -34,8 +34,28 @@
 #include "afv-native/http/TransferManager.h"
 #include "afv-native/http/Request.h"
 #include <curl/curl.h>
+#include <mutex>
 
 using namespace afv_native::http;
+
+namespace {
+    std::mutex gCurlGlobalMutex;
+    unsigned   gCurlGlobalRefCount = 0;
+} // namespace
+
+TransferManager::CurlGlobalGuard::CurlGlobalGuard() {
+    std::lock_guard<std::mutex> lock(gCurlGlobalMutex);
+    if (gCurlGlobalRefCount++ == 0) {
+        curl_global_init(CURL_GLOBAL_DEFAULT);
+    }
+}
+
+TransferManager::CurlGlobalGuard::~CurlGlobalGuard() {
+    std::lock_guard<std::mutex> lock(gCurlGlobalMutex);
+    if (--gCurlGlobalRefCount == 0) {
+        curl_global_cleanup();
+    }
+}
 
 TransferManager::TransferManager():
     mCurlMultiHandle(curl_multi_init()),

--- a/src/http/TransferManager.cpp
+++ b/src/http/TransferManager.cpp
@@ -41,12 +41,34 @@ TransferManager::TransferManager():
     mCurlMultiHandle(curl_multi_init()),
     mCurlShareHandle(curl_share_init()),
     mPendingTransfers() {
+    // Must be installed before anything is shared.
+    curl_share_setopt(mCurlShareHandle.get(), CURLSHOPT_LOCKFUNC, &TransferManager::curlShareLock);
+    curl_share_setopt(mCurlShareHandle.get(), CURLSHOPT_UNLOCKFUNC, &TransferManager::curlShareUnlock);
+    curl_share_setopt(mCurlShareHandle.get(), CURLSHOPT_USERDATA, this);
+
     // share everything.
     curl_share_setopt(mCurlShareHandle.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
     curl_share_setopt(mCurlShareHandle.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
     curl_share_setopt(mCurlShareHandle.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
     curl_share_setopt(mCurlShareHandle.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
     curl_share_setopt(mCurlShareHandle.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_PSL);
+}
+
+void TransferManager::curlShareLock(CURL *, curl_lock_data data, curl_lock_access, void *userptr) {
+    auto *tm = static_cast<TransferManager *>(userptr);
+    if (tm == nullptr || data >= CURL_LOCK_DATA_LAST) {
+        return;
+    }
+    // Exclusive for both SHARED and SINGLE access; these are short cache lookups.
+    tm->mShareLocks[static_cast<size_t>(data)].lock();
+}
+
+void TransferManager::curlShareUnlock(CURL *, curl_lock_data data, void *userptr) {
+    auto *tm = static_cast<TransferManager *>(userptr);
+    if (tm == nullptr || data >= CURL_LOCK_DATA_LAST) {
+        return;
+    }
+    tm->mShareLocks[static_cast<size_t>(data)].unlock();
 }
 
 TransferManager::~TransferManager() {


### PR DESCRIPTION
## What

The hourly JWT refresh could be submitted and then never complete - no
success callback, no error callback, nothing. Since mRefreshTokenTimer is
only re-armed inside _authenticationCallback, that left APISession stuck
in Reconnecting permanently with no retry. The old token expired a minute
later, every subsequent request got 401'd, and the session was effectively
dead until a manual reconnect.

## Context

My previous PR (thread safety in Request::reset) fixed the hourly
libcurl.dll crash, but it also changed doAsync() to call shareState()
before submitting the request. That call had previously been a no-op -
it ran on a null curl handle, so the CURLSH share was configured but never
actually attached to any easy handle. Fixing that ordering made the share
handle live for the first time, and it turns out we're sharing
CURL_LOCK_DATA_CONNECT (the connection cache) across the poll thread and
every session-timer thread with no CURLSHOPT_LOCKFUNC/UNLOCKFUNC, which
libcurl documents as required for cross-thread use. I think that's the
Title:
Fix hung token refresh stranding the session in Reconnecting
## What

The hourly JWT refresh could be submitted and then never complete - no
success callback, no error callback, nothing. Since mRefreshTokenTimer is
only re-armed inside _authenticationCallback, that left APISession stuck
in Reconnecting permanently with no retry. The old token expired a minute
later, every subsequent request got 401'd, and the session was effectively
dead until a manual reconnect.

## Context

My previous PR (thread safety in Request::reset) fixed the hourly
libcurl.dll crash, but it also changed doAsync() to call shareState()
before submitting the request. That call had previously been a no-op -
it ran on a null curl handle, so the CURLSH share was configured but never
actually attached to any easy handle. Fixing that ordering made the share
handle live for the first time, and it turns out we're sharing
CURL_LOCK_DATA_CONNECT (the connection cache) across the poll thread and
every session-timer thread with no CURLSHOPT_LOCKFUNC/UNLOCKFUNC, which
libcurl documents as required for cross-thread use. I think that's the
most likely mechanism behind this hang, though I can't prove it from a
single log capture.

## Changes

- CURLOPT_CONNECTTIMEOUT / CURLOPT_TIMEOUT on every request (10s/30s
UNLOCKFUNC installed on the share handle, backed by
  a per-datum mutex array declared so it outlives curl_share_cleanup.
- The refresh timer is now armed before the request is dispatched rather
  than only on completion, so a request that never calls back gets
  reissued via a 45s watchdog instead of stranding the session forever.
- A failed refresh no longer tears down a live session outright - it
  retries with backoff while the current token still has time on it, and
  only fails for real once the token can't carry the session any further.

## Testing

I have tested this for 3 hours today with no issues at all.

And note: this pr description was written for me by claude if anyone wants to say: "looks like ai" it is
Some of the code was also done using claude but I verified the code and it looked good to me