### PR TITLE
Fix CallbackTimer firing in a hot loop after its first expiry

### DIFF
--- a/include/afv-native/event/CallbackTimer.h
+++ b/include/afv-native/event/CallbackTimer.h
@@ -1,6 +1,7 @@
 #ifndef AFV_NATIVE_CALLBACKTIMER_H
 #define AFV_NATIVE_CALLBACKTIMER_H
 
+#include <Poco/Clock.h>
 #include <Poco/Util/Timer.h>
 #include <Poco/Util/TimerTask.h>
 #include <atomic>

--- a/src/event/CallbackTimer.cpp
+++ b/src/event/CallbackTimer.cpp
@@ -47,7 +47,14 @@ void CallbackTimer::enable(unsigned int delayMs) {
     }
     mPending.store(true);
     mTask = new CallbackTimerTask(mCallback, mPending);
-    mTimer.schedule(mTask, static_cast<long>(delayMs), 0);
+
+    // One-shot. The schedule(task, delay, interval) overload is the PERIODIC
+    // one: passing 0 as the interval re-runs the task with no delay, forever,
+    // from the moment it first fires. Every caller here re-arms from inside its
+    // own callback, so a repeating task is never what is wanted.
+    Poco::Clock clock;
+    clock += static_cast<Poco::Clock::ClockDiff>(delayMs) * 1000; // ms -> us
+    mTimer.schedule(mTask, clock);
 }
 
 void CallbackTimer::disable() {


### PR DESCRIPTION

`src/event/CallbackTimer.cpp:50`, introduced in `92494ab Remove libevent`:

```cpp
mTimer.schedule(mTask, static_cast<long>(delayMs), 0);
```

`Poco::Util::Timer::schedule(task, delay, interval)` is the **periodic** overload. Poco's own docs:

> Schedules a task for periodic execution. The task is first executed after the given delay. Subsequently, the task is executed periodically with the given interval in milliseconds between invocations.

An interval of `0` means re-run with no delay, forever, from the moment the task first fires.

## Why nobody caught it

Every user of this class re-arms from inside its own callback, so the *initial* delay is always honoured and nothing repeats until a timer actually **expires**. For the token refresh that is 59 minutes after login.

## Measured

Loopback auth server issuing a token that expires in 62s, which puts the refresh timer at 2s:

**Before**
```
[  0.018s]   state -> Connecting
[  0.029s] auth hit #1
[  0.030s]   state -> Running          <- 2s timer armed
[  2.030s]   state -> Reconnecting     <- timer fires
[  2.032s] auth hit #2
[  2.032s] auth hit #3
[  2.033s] auth hit #4
...  ~1000 auth requests/second, indefinitely
```

**After**
```
[  0.017s] auth hit #1
[  2.024s] auth hit #2
[  4.030s] auth hit #3
[  6.033s] auth hit #4
```

## Why this matters

This is very likely the root cause of the symptom #19 was chasing — an hourly refresh submitted that never completed, leaving the session stuck in `Reconnecting`. Thousands of concurrent `Connect()` calls all `reset()`-ing and re-issuing the same shared `RESTRequest` also fits the "curl access violation in multithreaded environment" this repo has two commits named after.

Beyond the wedged session, this is hammering the AFV auth endpoint with ~1000 requests/second from every affected client, an hour into every session.

## The fix

The one-shot `Poco::Clock` overload. `Clock` rather than `Timestamp` because it is monotonic and will not be dragged by an NTP correction.

## Scope

Affects **every** `CallbackTimer` user, not just auth: the token refresh, the voice session heartbeat and its timeout, and the transceiver update timer. Those re-arm on a short cycle so the window is smaller, but the same runaway applies whenever one expires without being re-armed first.

## Verification

Clean Release build on macOS arm64, zero warnings. Behaviour verified with the timing capture above; the regression test that produced it lives in #20, which has the loopback harness.