### PR TITLE
Preserve VCCS station ordering metadata

### DIFF
--- a/include/afv-native/afv/dto/Station.h
+++ b/include/afv-native/afv/dto/Station.h
@@ -35,6 +35,8 @@
 #define AFV_NATIVE_STATION_H
 
 #include <nlohmann/json.hpp>
+#include <cstddef>
+#include <optional>
 #include <string>
 
 namespace afv_native { namespace afv { namespace dto {
@@ -44,6 +46,8 @@ namespace afv_native { namespace afv { namespace dto {
         std::string  Name;
         unsigned int Frequency;
         unsigned int FrequencyAlias;
+        // Zero-based position in a VCCS response. Empty for ordinary station data.
+        std::optional<std::size_t> VccsOrder = std::nullopt;
 
         Station();
     };

--- a/include/afv-native/types.h
+++ b/include/afv-native/types.h
@@ -2,6 +2,8 @@
 #define AFV_NATIVE_COMMON_TYPES_H
 
 #include "hardwareType.h"
+#include <cstddef>
+#include <optional>
 #include <string>
 
 namespace afv_native {
@@ -23,6 +25,8 @@ namespace afv_native {
         std::string  name;
         unsigned int frequency;
         unsigned int frequencyAlias;
+        // Zero-based position returned by the AFV VCCS endpoint, when available.
+        std::optional<std::size_t> vccsOrder = std::nullopt;
     };
 } // namespace afv_native
 

--- a/src/afv/APISession.cpp
+++ b/src/afv/APISession.cpp
@@ -335,12 +335,12 @@ void APISession::_stationVccsCallback(const http::Response &resp, std::string st
         if (!jsReturn.is_array()) {
             LOG("APISession", "station vccs data returned wasn't an array.  Ignoring.");
         } else {
-            std::size_t vccsOrder = 0;
-            for (const auto &sJson: jsReturn) {
+            for (std::size_t vccsOrder = 0; vccsOrder < jsReturn.size(); ++vccsOrder) {
+                const auto &sJson = jsReturn[vccsOrder];
                 try {
                     dto::Station s;
                     sJson.get_to(s);
-                    s.VccsOrder = vccsOrder++;
+                    s.VccsOrder = vccsOrder;
                     ret.insert({sJson["name"].get<std::string>(), s});
                 } catch (nlohmann::json::exception &e) {
                     LOG("APISession", "couldn't decode station vccs: %s", e.what());

--- a/src/afv/APISession.cpp
+++ b/src/afv/APISession.cpp
@@ -335,10 +335,12 @@ void APISession::_stationVccsCallback(const http::Response &resp, std::string st
         if (!jsReturn.is_array()) {
             LOG("APISession", "station vccs data returned wasn't an array.  Ignoring.");
         } else {
+            std::size_t vccsOrder = 0;
             for (const auto &sJson: jsReturn) {
                 try {
                     dto::Station s;
                     sJson.get_to(s);
+                    s.VccsOrder = vccsOrder++;
                     ret.insert({sJson["name"].get<std::string>(), s});
                 } catch (nlohmann::json::exception &e) {
                     LOG("APISession", "couldn't decode station vccs: %s", e.what());

--- a/src/core/atcClient.cpp
+++ b/src/core/atcClient.cpp
@@ -553,7 +553,8 @@ void ATCClient::stationVccsCallback(std::string stationName, std::map<std::strin
     for (const auto &el: vccs) {
         vccsFreqs[el.first] = el.second.Frequency;
         vccsSimple[el.first] =
-            SimpleAtcStation {el.second.Name, el.second.Frequency, el.second.FrequencyAlias};
+            SimpleAtcStation {el.second.Name, el.second.Frequency, el.second.FrequencyAlias,
+                              el.second.VccsOrder};
     }
     LOG("ATCClient", "Received VCCS for station %s", stationName.c_str());
     event::EventBus::Instance().OnEventAsync(VccsReceivedEvent {stationName, vccsSimple});

--- a/tests/afv/test_api_session.cpp
+++ b/tests/afv/test_api_session.cpp
@@ -162,6 +162,7 @@ TEST_CASE("VCCS stations retain the order returned by the API", "[apisession][vc
             resp.setContentType("application/json");
             resp.send() << R"([
                 {"id":"1","name":"EKCH_W_APP","frequency":119805000,"frequencyAlias":0},
+                {"id":"invalid-without-name"},
                 {"id":"2","name":"EKCH_R_DEP","frequency":120255000,"frequencyAlias":0},
                 {"id":"3","name":"EKCH_O_APP","frequency":118155000,"frequencyAlias":0},
                 {"id":"4","name":"EKCH_K_DEP","frequency":124980000,"frequencyAlias":0}
@@ -200,9 +201,9 @@ TEST_CASE("VCCS stations retain the order returned by the API", "[apisession][vc
 
     REQUIRE(stations.size() == 4);
     REQUIRE(stations.at("EKCH_W_APP").VccsOrder == 0);
-    REQUIRE(stations.at("EKCH_R_DEP").VccsOrder == 1);
-    REQUIRE(stations.at("EKCH_O_APP").VccsOrder == 2);
-    REQUIRE(stations.at("EKCH_K_DEP").VccsOrder == 3);
+    REQUIRE(stations.at("EKCH_R_DEP").VccsOrder == 2);
+    REQUIRE(stations.at("EKCH_O_APP").VccsOrder == 3);
+    REQUIRE(stations.at("EKCH_K_DEP").VccsOrder == 4);
 
     session.Disconnect();
 }

--- a/tests/afv/test_api_session.cpp
+++ b/tests/afv/test_api_session.cpp
@@ -145,3 +145,65 @@ TEST_CASE("an unreachable API server reports a connection error", "[apisession]"
     REQUIRE(session.getLastError() == APISessionError::ConnectionError);
 }
 
+TEST_CASE("VCCS stations retain the order returned by the API", "[apisession][vccs]") {
+    dto::Station ordinaryStation;
+    REQUIRE_FALSE(ordinaryStation.VccsOrder.has_value());
+
+    afv_test::LoopbackServer server([](const std::string &method, const std::string &path,
+                                       const std::string &, Poco::Net::HTTPServerResponse &resp) {
+        if (path == "/api/v1/auth" && method == "POST") {
+            resp.setStatus(Poco::Net::HTTPResponse::HTTP_OK);
+            resp.setContentType("text/plain");
+            resp.send() << mintToken(3600);
+            return;
+        }
+        if (path == "/api/v1/stations/byName/EKCH_W_APP/vccsStations" && method == "GET") {
+            resp.setStatus(Poco::Net::HTTPResponse::HTTP_OK);
+            resp.setContentType("application/json");
+            resp.send() << R"([
+                {"id":"1","name":"EKCH_W_APP","frequency":119805000,"frequencyAlias":0},
+                {"id":"2","name":"EKCH_R_DEP","frequency":120255000,"frequencyAlias":0},
+                {"id":"3","name":"EKCH_O_APP","frequency":118155000,"frequencyAlias":0},
+                {"id":"4","name":"EKCH_K_DEP","frequency":124980000,"frequencyAlias":0}
+            ])";
+            return;
+        }
+        resp.setStatus(Poco::Net::HTTPResponse::HTTP_NOT_FOUND);
+        resp.send() << "";
+    });
+
+    http::TransferManager tm;
+    APISession            session(tm, server.url(""), "afv-native-test");
+    session.setUsername("tester");
+    session.setPassword("hunter2");
+
+    Counter runningStates;
+    session.StateCallback.addCallback(nullptr, [&](APISessionState state) {
+        if (state == APISessionState::Running) {
+            runningStates.bump();
+        }
+    });
+
+    std::map<std::string, dto::Station> stations;
+    Counter                             vccsResponses;
+    session.StationVccsCallback.addCallback(
+        nullptr, [&](const std::string &, std::map<std::string, dto::Station> response) {
+            stations = std::move(response);
+            vccsResponses.bump();
+        });
+
+    session.Connect();
+    REQUIRE(runningStates.waitFor(1, std::chrono::seconds(30)));
+
+    session.requestStationVccs("EKCH_W_APP");
+    REQUIRE(vccsResponses.waitFor(1, std::chrono::seconds(30)));
+
+    REQUIRE(stations.size() == 4);
+    REQUIRE(stations.at("EKCH_W_APP").VccsOrder == 0);
+    REQUIRE(stations.at("EKCH_R_DEP").VccsOrder == 1);
+    REQUIRE(stations.at("EKCH_O_APP").VccsOrder == 2);
+    REQUIRE(stations.at("EKCH_K_DEP").VccsOrder == 3);
+
+    session.Disconnect();
+}
+


### PR DESCRIPTION
## Summary

- preserve the zero-based order of stations returned by the AFV VCCS endpoint
- expose that order as optional metadata on `Station` and `SimpleAtcStation`
- keep the existing callsign-keyed map callbacks and events intact
- add a loopback regression test using a deliberately non-alphabetical EKCH station sequence

## Why

The VCCS endpoint returns an ordered JSON array, but `APISession` stores those stations in an `std::map` keyed by callsign. Consumers therefore receive callsign order and cannot recover the order configured in the AFV editor.

TrackAudio issue [pierr3/TrackAudio#343](https://github.com/pierr3/TrackAudio/issues/343) requests an optional display mode using the AFV editor order. This metadata makes that possible without changing AFV-native's existing map-based callback and event API.

## Compatibility and behavior

- `VccsOrder` / `vccsOrder` is zero-based and populated only for VCCS responses.
- Ordinary station search results leave the optional value empty.
- Existing map lookup and iteration behavior remains unchanged.
- Consumers that do not use the new field continue to behave as before.

## Validation

- Windows Release native build completed successfully through TrackAudio's backend build.
- Added a Catch2 loopback regression test that verifies the API sequence `EKCH_W_APP`, `EKCH_R_DEP`, `EKCH_O_APP`, `EKCH_K_DEP` survives map sorting through the recorded order values.
- The repository's test target is documented as Unix-only because the required DTO/event symbols are not exported under MSVC, so the new test was not executed in this Windows checkout.
