### PR TITLE
Remove audio device check in setLoopback method as subfunction did no…

### DIFF
--- a/src/core/atcClient.cpp
+++ b/src/core/atcClient.cpp
@@ -793,9 +793,5 @@ void afv_native::ATCClient::stopAdHocSounds() {
 }
 
 void afv_native::ATCClient::setLoopback(bool enabled, AdHocOutputTarget target, float gain, HardwareType hardware) {
-    if (!mAudioDevice) {
-        LOG("afv::ATCClient", "setLoopback: audio not running, ignoring");
-        return;
-    }
     mATCRadioStack->setLoopback(enabled, target, gain, hardware);
 }


### PR DESCRIPTION
…t need it and was breaking trackaudio loopback implementation as called before any audio devices was setup.
Fixes https://github.com/pierr3/TrackAudio/issues/355